### PR TITLE
Broaden parsing to handle meshes as used in the Apptronik Apollo model

### DIFF
--- a/mujoco_importer.py
+++ b/mujoco_importer.py
@@ -706,7 +706,7 @@ def parse_mujoco_xml(filepath, blenderclass):
         for m in a.findall("mesh"):
             filename = m.get("file", None)
             if filename is not None:
-                mesh_files[os.path.splitext(filename)[0]] = os.path.join(stl_dir_full, filename)
+                mesh_files[os.path.splitext(os.path.split(filename)[-1])[0]] = os.path.join(stl_dir_full, filename)
 
     joints = []
     bodies = []
@@ -742,7 +742,7 @@ def parse_mujoco_xml(filepath, blenderclass):
         for geom in body.findall("geom"):
             geom_type = geom.get("type", "unknown")
             geom_class = geom.get("class", "unknown")
-            if geom_type == "mesh" and geom_class == "visual":
+            if (geom_type == "mesh" or geom_type == "unknown") and (geom_class == "visual" or geom_class == "visual_light" or geom_class == "visual_dark"):
                 geom_meshfile = geom.get("mesh", None)
                 if geom_meshfile is not None:
                     body_info.add_mesh_geom(MeshGeomInfo(mesh_files[os.path.splitext(geom_meshfile)[0]]))


### PR DESCRIPTION
I needed these minor tweaks to the XML interpretation to load the Apptronik Apollo humanoid model: https://github.com/google-deepmind/mujoco_menagerie/tree/main/apptronik_apollo.

With these changes, meshes load for elements that look like `<geom class="visual_light" mesh="torso_link"/>` or `<geom class="visual_dark" mesh="torso_pitch_link"/>` (in addition to the apparently intended `<geom class="visual" type="mesh" mesh="foo">` format). Also, names are resolved correctly (I think) for meshes that are further down in the directory hierarchy; e.g., `<mesh file="ability_hand/wrist_adapter.STL"/>` is later referenced like this: `<geom name="wrist_adapter_mesh" pos="0 -0.0297676 -0.0277946" class="visual_dark" mesh="wrist_adapter"/>`.

Caveat: I'm not at all familiar with the MJCF spec.
